### PR TITLE
Change ignore pattern for `node_modules`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 /out-tsc
 
 # dependencies
-/node_modules
+node_modules
 
 # IDEs and editors
 /.idea


### PR DESCRIPTION
I think that this will resolve your issue reported [here](https://github.com/changesets/action/issues/160).

I'm not sure why this behaves differently for you locally - perhaps you have some other `.gitignore` files elsewhere? Like higher in the directory tree? I'm not sure.

But I've tested a fresh close of this repo here. I've added a dummy file to one of the affected `node_modules` in your `packages`: `packages/eslint-config-base/node_modules/.bin/test.js`.

The result with the current pattern:
```bash
gitpod /workspace/toolkit (main) $ git status
On branch main
Your branch is up to date with 'origin/main'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        .gitpod.yml
        packages/eslint-config-base/node_modules/.bin/test.js

nothing added to commit but untracked files present (use "git add" to track)
```

The result with the proposed change:
```bash
gitpod /workspace/toolkit (main) $ git status
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   .gitignore

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        .gitpod.yml

no changes added to commit (use "git add" and/or "git commit -a")
```

(ignore the `.gitpod.yml` file, it has been added automatically by gitpod and is irrelevant to the issue here).

Basically the leading `/` scopes the ignore pattern to the related `.gitignore` file:
> If there is a separator at the beginning or middle (or both) of the pattern, then the pattern is relative to the directory level of the particular .gitignore file itself. Otherwise the pattern may also match at any level below the .gitignore level.

By removing it we have a pattern that ignores such a directory on all levels.